### PR TITLE
Fixed number of nodes expanded being stochastic:

### DIFF
--- a/src/main/java/BasicCBS/Solvers/AStar/SingleAgentAStar_Solver.java
+++ b/src/main/java/BasicCBS/Solvers/AStar/SingleAgentAStar_Solver.java
@@ -357,14 +357,19 @@ public class SingleAgentAStar_Solver extends A_Solver {
 
     private static class TieBreakingForHigherGComparator implements Comparator<AStarState>{
 
-        Comparator<AStarState> fComparator = Comparator.comparing(AStarState::getF);
+        private static Comparator<AStarState> fComparator = Comparator.comparing(AStarState::getF);
 
         @Override
         public int compare(AStarState o1, AStarState o2) {
-            if(Math.abs(o1.getF() - o2.getF()) < 0.001){ // floats are equal
+            if(Math.abs(o1.getF() - o2.getF()) < 0.1){ // floats are equal
                 // if f() value is equal, we consider the state with higher g() to be better (smaller). Therefore, we
                 // want to return a negative integer if o1.g is bigger than o2.g
-                return o2.g - o1.g;
+                if (o2.g == o1.g){
+                    return o1.hashCode() - o2.hashCode();
+                }
+                else {
+                    return o2.g - o1.g;
+                }
             }
             else {
                 return fComparator.compare(o1, o2);

--- a/src/main/java/BasicCBS/Solvers/CBS/CBS_Solver.java
+++ b/src/main/java/BasicCBS/Solvers/CBS/CBS_Solver.java
@@ -95,7 +95,7 @@ public class CBS_Solver extends A_Solver {
         clearOPEN();
         // if a specific cost function is not provided, use standard SOC (Sum of Individual Costs)
         this.costFunction = costFunction != null ? costFunction : (solution, cbs) -> solution.sumIndividualCosts();
-        this.CBSNodeComparator = cbsNodeComparator != null ? cbsNodeComparator : Comparator.comparing(CBS_Node::getSolutionCost);
+        this.CBSNodeComparator = cbsNodeComparator != null ? cbsNodeComparator : new CBSNodeComparatorForcedTotalOrdering();
     }
 
     /**
@@ -528,7 +528,22 @@ public class CBS_Solver extends A_Solver {
             return Objects.compare(this, o, CBS_Solver.this.CBSNodeComparator);
         }
 
+    }
 
+    public static class CBSNodeComparatorForcedTotalOrdering implements Comparator<CBS_Node>{
+
+        private static final Comparator<CBS_Node> costComparator = Comparator.comparing(CBS_Node::getSolutionCost);
+
+        @Override
+        public int compare(CBS_Node o1, CBS_Node o2) {
+            if(Math.abs(o1.getSolutionCost() - o2.getSolutionCost()) < 0.1){ // floats are equal
+                // if f() value is equal, we force a total ordering with hashCode() to remain deterministic
+                return o1.hashCode() - o2.hashCode();
+            }
+            else {
+                return costComparator.compare(o1, o2);
+            }
+        }
     }
 
 


### PR DESCRIPTION
1. increased the delta for floating point equality.
2. forced a total ordering on nodes by using hashCode().
3. implemented those for both AStar and CBS nodes.
May consider swapping these uses of floating points for integers.