### PR TITLE
Fixed number of nodes expanded being stochastic:

### DIFF
--- a/src/main/java/BasicCBS/Solvers/AStar/SingleAgentAStar_Solver.java
+++ b/src/main/java/BasicCBS/Solvers/AStar/SingleAgentAStar_Solver.java
@@ -187,7 +187,6 @@ public class SingleAgentAStar_Solver extends A_Solver {
                 if (constraints.accepts(possibleMove)) { //move not prohibited by existing constraint
                     AStarState rootState = new AStarState(possibleMove, null, 1);
                     openList.add(rootState);
-                    generatedNodes++;
                 }
             }
 
@@ -234,10 +233,15 @@ public class SingleAgentAStar_Solver extends A_Solver {
 
     public class AStarState implements Comparable<AStarState>{
 
-        private Move move;
-        private AStarState prev;
-        private int g;
-        private float h;
+        /**
+         * Needed to enforce total ordering on nodes, which is needed to make node expansions fully deterministic. That
+         * is to say, if all tie breaking methods still result in equality, tie break for using serialID.
+         */
+        private final int serialID = SingleAgentAStar_Solver.this.generatedNodes++; // take and increment
+        private final Move move;
+        private final AStarState prev;
+        private final int g;
+        private final float h;
 
         public AStarState(Move move, AStarState prevState, int g) {
             this.move = move;
@@ -282,7 +286,6 @@ public class SingleAgentAStar_Solver extends A_Solver {
                 Move possibleMove = new Move(this.move.agent, this.move.timeNow+1, this.move.currLocation, destination);
                 if(constraints.accepts(possibleMove)){ //move not prohibited by existing constraint
                     AStarState child = new AStarState(possibleMove, this, this.g + 1);
-                    generatedNodes++; //field in containing class
 
                     AStarState existingState;
                     if(closed.contains(child)){ // state visited already
@@ -365,10 +368,11 @@ public class SingleAgentAStar_Solver extends A_Solver {
                 // if f() value is equal, we consider the state with higher g() to be better (smaller). Therefore, we
                 // want to return a negative integer if o1.g is bigger than o2.g
                 if (o2.g == o1.g){
-                    return o1.hashCode() - o2.hashCode();
+                    // If still equal, we tie break for smaller ID (older nodes) (arbitrary) to force a total ordering and remain deterministic
+                    return o2.serialID - o1.serialID;
                 }
                 else {
-                    return o2.g - o1.g;
+                    return o2.g - o1.g; //higher g is better
                 }
             }
             else {

--- a/src/main/java/BasicCBS/Solvers/CBS/CBS_Solver.java
+++ b/src/main/java/BasicCBS/Solvers/CBS/CBS_Solver.java
@@ -151,8 +151,6 @@ public class CBS_Solver extends A_Solver {
      * Creates a root node.
      */
     private CBS_Node generateRoot(ConstraintSet initialConstraints) {
-        this.generatedNodes++;
-
         Solution solution = new Solution(); // init an empty solution
         // for every agent, add its plan to the solution
         for (Agent agent :
@@ -248,8 +246,6 @@ public class CBS_Solver extends A_Solver {
      * @return a new {@link CBS_Node}.
      */
     private CBS_Node generateNode(CBS_Node parent, Constraint constraint, boolean copyDatastructures) {
-        this.generatedNodes++;
-
         Agent agent = constraint.agent;
 
         Solution solution = parent.solution;
@@ -428,6 +424,11 @@ public class CBS_Solver extends A_Solver {
          * A {@link A_Conflict conflict}, selected to be solved by new constraints in child nodes.
          */
         private A_Conflict selectedConflict;
+        /**
+         * Needed to enforce total ordering on nodes, which is needed to make node expansions fully deterministic. That
+         * is to say, if all tie breaking methods still result in equality, tie break for using serialID.
+         */
+        private final int serialID = CBS_Solver.this.generatedNodes++; // take and increment
 
         /*  =  =  = CBS tree branches =  =  */
 
@@ -537,8 +538,8 @@ public class CBS_Solver extends A_Solver {
         @Override
         public int compare(CBS_Node o1, CBS_Node o2) {
             if(Math.abs(o1.getSolutionCost() - o2.getSolutionCost()) < 0.1){ // floats are equal
-                // if f() value is equal, we force a total ordering with hashCode() to remain deterministic
-                return o1.hashCode() - o2.hashCode();
+                // If still equal, we tie break for smaller ID (older nodes) (arbitrary) to force a total ordering and remain deterministic
+                return o2.serialID- o1.serialID;
             }
             else {
                 return costComparator.compare(o1, o2);

--- a/src/test/java/BasicCBS/Solvers/CBS/CBS_SolverTest.java
+++ b/src/test/java/BasicCBS/Solvers/CBS/CBS_SolverTest.java
@@ -304,7 +304,9 @@ class CBS_SolverTest {
                                 "Cost Delta",
                                 InstanceReport.StandardFields.totalLowLevelTimeMS,
                                 InstanceReport.StandardFields.generatedNodes,
-                                InstanceReport.StandardFields.expandedNodes});
+                                InstanceReport.StandardFields.expandedNodes,
+                                InstanceReport.StandardFields.generatedNodesLowLevel,
+                                InstanceReport.StandardFields.expandedNodesLowLevel});
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Using hashCode() was insufficient for forcing a total ordering. Probably because it uses memory addresses of nodes, the order of which can change between runs.
Now using a counter based on the generatedNodes fields. Also consolidated incrementation of those fields to just one place in each solver (in node constructor).