### PR TITLE
bugfix: sub-optimal when preserving roots

### DIFF
--- a/src/main/java/BasicCBS/Solvers/Solution.java
+++ b/src/main/java/BasicCBS/Solvers/Solution.java
@@ -153,7 +153,7 @@ public class Solution implements Iterable<SingleAgentPlan>{
 
     @Override
     public String toString() {
-        return agentPlans.values().toString();
+        return this.readableToString();
     }
 
     //nicetohave JSON toString

--- a/src/main/java/OnlineMAPF/Solvers/OnlineCompatibleOfflineCBS.java
+++ b/src/main/java/OnlineMAPF/Solvers/OnlineCompatibleOfflineCBS.java
@@ -3,18 +3,21 @@ package OnlineMAPF.Solvers;
 import BasicCBS.Instances.Agent;
 import BasicCBS.Instances.MAPF_Instance;
 import BasicCBS.Instances.Maps.I_Location;
-import BasicCBS.Solvers.*;
 import BasicCBS.Solvers.AStar.DistanceTableAStarHeuristic;
 import BasicCBS.Solvers.AStar.RunParameters_SAAStar;
 import BasicCBS.Solvers.CBS.CBS_Solver;
 import BasicCBS.Solvers.ConstraintsAndConflicts.ConflictManagement.I_ConflictManager;
 import BasicCBS.Solvers.ConstraintsAndConflicts.ConflictManagement.NaiveConflictDetection;
-import BasicCBS.Solvers.ConstraintsAndConflicts.ConflictManagement.SingleUseConflictAvoidanceTable;
 import BasicCBS.Solvers.ConstraintsAndConflicts.Constraint.ConstraintSet;
+import BasicCBS.Solvers.RunParameters;
+import BasicCBS.Solvers.SingleAgentPlan;
+import BasicCBS.Solvers.Solution;
 import Environment.Metrics.InstanceReport;
-import OnlineMAPF.*;
+import OnlineMAPF.OnlineAgent;
+import OnlineMAPF.OnlineConstraintSet;
+import OnlineMAPF.OnlineDistanceTableAStarHeuristic;
+import OnlineMAPF.OnlineSolution;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -100,7 +103,8 @@ public class OnlineCompatibleOfflineCBS extends CBS_Solver {
                 }
                 else{
                     trimmedPlanCopy = new SingleAgentPlan(agent);
-                    for(int time = customStartTime; time <= existingPlan.getEndTime(); time++){
+                    for(int time = customStartTime + 1 /*starts with the move that comes after the arrival of the new agents*/
+                        ; time <= existingPlan.getEndTime(); time++){
                         trimmedPlanCopy.addMove(existingPlan.moveAt(time));
                     }
                 }

--- a/src/test/java/OnlineMAPF/Solvers/OnlineCBSSolverTest.java
+++ b/src/test/java/OnlineMAPF/Solvers/OnlineCBSSolverTest.java
@@ -81,6 +81,13 @@ class OnlineCBSSolverTest {
     };
     private I_Map mapCorridors = MapFactory.newSimple4Connected2D_GraphMap(map_2D_corridors);
 
+    private Enum_MapCellType[][] CompetitiveRatio_Diameter_5 = {
+            {e, e, e, e},
+            {e, w, w, e},
+            {e, e, e, e},
+    };
+    private I_Map mapCompetitiveRatio_Diameter_5 = MapFactory.newSimple4Connected2D_GraphMap(CompetitiveRatio_Diameter_5);
+
     private I_Coordinate coor12 = new Coordinate_2D(1,2);
     private I_Coordinate coor13 = new Coordinate_2D(1,3);
     private I_Coordinate coor14 = new Coordinate_2D(1,4);
@@ -126,6 +133,9 @@ class OnlineCBSSolverTest {
     private OnlineAgent agent53to05t7 = new OnlineAgent(new Agent(12, coor53, coor05), 7);
     private OnlineAgent agent12to33t0anotherOne = new OnlineAgent(new Agent(13, coor12, coor33), 0);
 
+    private OnlineAgent agent13to10 = new OnlineAgent(0, coor13, coor10, 0);
+    private OnlineAgent agent00to02 = new OnlineAgent(1, coor00, coor02, 3);
+
     InstanceBuilder_BGU builder = new OnlineInstanceBuilder_BGU();
     InstanceManager im_BGU = new InstanceManager(IO_Manager.buildPath( new String[]{   IO_Manager.testResources_Directory,"Instances", "Online"}),
             builder, new InstanceProperties());
@@ -146,6 +156,8 @@ class OnlineCBSSolverTest {
     private MAPF_Instance instanceMultipleAgentsSameSourcesTargets = new MAPF_Instance("instanceEmpty", mapEmpty, new Agent[]
             {agent12to33t0, agent12to34t0, agent11to33t0, agent12to33t1, agent12to33t3, agent12to33t6, agent12to33t7, agent53to05t1,
                     agent53to05t4, agent53to05t5, agent53to05t6, agent53to05t7, agent12to33t0anotherOne});
+    private MAPF_Instance instanceDiameter5 = new MAPF_Instance("instanceDiameter5", mapCompetitiveRatio_Diameter_5,
+            new Agent[]{agent13to10, agent00to02});
 
     private I_Solver solver = new OnlineSolverContainer(new OnlineCBSSolver());
 
@@ -521,5 +533,15 @@ class OnlineCBSSolverTest {
         // reroutes don't happen when solving offline, so should be 0.
         int rerouteCostsWhenOffline = ((OnlineSolution)solvedOffline).costOfReroutes(costOfReroute);
         assertEquals(0, rerouteCostsWhenOffline);
+    }
+
+    @Test
+    void optimalWhenUsingPreserveSolutionInRoot() {
+        MAPF_Instance testInstance = instanceDiameter5;
+        I_Solver solverWithRootPreservation = new OnlineSolverContainer(new OnlineCBSSolver(true));
+        Solution solved = solverWithRootPreservation.solve(testInstance, new RunParameters(instanceReport));
+
+        System.out.println(solved.readableToString());
+        validate(solved, 2, 9, 5, testInstance);
     }
 }


### PR DESCRIPTION
* When using the option to preserve existing plans in new roots, sometimes the solution would be suboptimal. The solutions in the root contained one too many steps (started too early). Therefore, constraining existing agents was sometimes preferred because it removed the first move and shortened the plan.
* added a test for this bug for regression testing.
* changed Solution.toString to use readableToString for easier debugging and readable console output.